### PR TITLE
Implement message CRUD

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url =

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+import asyncio
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection
+from alembic import context
+
+from app.core.settings import get_settings
+from app.db.base import Base
+from app.db.models import message  # ensure models are imported
+
+config = context.config
+fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", str(settings.database.url))
+
+target_metadata = Base.metadata
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async def do_run_migrations(connection: Connection) -> None:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        await context.run_async_migrations()
+
+    asyncio.run(do_run_migrations(connectable.connect()))
+
+run_migrations_online()

--- a/migrations/versions/0001_create_messages_table.py
+++ b/migrations/versions/0001_create_messages_table.py
@@ -1,0 +1,24 @@
+"""create messages table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Uuid, primary_key=True, default=sa.text("gen_random_uuid()") if op.get_bind().dialect.name == "postgresql" else None),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("author", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now(), onupdate=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("messages")

--- a/src/app/api/api.py
+++ b/src/app/api/api.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 
-from app.core.settings import get_settings
+from app.api.routes import healthcheck, messages
 
-settings = get_settings()
+router = APIRouter()
+router.include_router(healthcheck.router)
+router.include_router(messages.router)
 

--- a/src/app/api/routes/healthcheck.py
+++ b/src/app/api/routes/healthcheck.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from schemas.healthcheck import HealthCheckResponse
+from app.db.session import get_async_session
 from app.services.health_service import HealthCheckService
 from app.infrastructure.health.repository import DefaultHealthCheckRepository
 from app.infrastructure.health.dao import HealthDAO
@@ -7,7 +8,7 @@ from app.infrastructure.health.dao import HealthDAO
 router = APIRouter()
 
 @router.get("/health", response_model=HealthCheckResponse)
-async def healthcheck(session=Depends(get_db_session)) -> HealthCheckResponse:
+async def healthcheck(session=Depends(get_async_session)) -> HealthCheckResponse:
     """Endpoint to check the health of the application."""
     dao = HealthDAO(session)
     repo = DefaultHealthCheckRepository(dao)

--- a/src/app/api/routes/messages.py
+++ b/src/app/api/routes/messages.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import uuid
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.message import MessageCreate, MessageUpdate, MessageRead
+from app.db.session import get_async_session
+from app.infrastructure.messages.repository import MessageRepository
+from app.infrastructure.messages.dao import MessageDAO
+from app.services.message_service import MessageService
+
+router = APIRouter(prefix="/api/messages")
+
+
+def get_service(session: AsyncSession = Depends(get_async_session)) -> MessageService:
+    repo = MessageRepository(session)
+    dao = MessageDAO(repo)
+    return MessageService(dao)
+
+
+@router.post("/", response_model=MessageRead, status_code=201)
+async def create_message(message: MessageCreate, service: MessageService = Depends(get_service)) -> MessageRead:
+    created = await service.create_message(message)
+    return MessageRead.model_validate(created)
+
+
+@router.get("/", response_model=list[MessageRead])
+async def list_messages(service: MessageService = Depends(get_service)) -> list[MessageRead]:
+    messages = await service.get_all_messages()
+    return [MessageRead.model_validate(m) for m in messages]
+
+
+@router.get("/{message_id}", response_model=MessageRead)
+async def get_message(message_id: uuid.UUID, service: MessageService = Depends(get_service)) -> MessageRead:
+    message = await service.get_message(message_id)
+    if not message:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return MessageRead.model_validate(message)
+
+
+@router.put("/{message_id}", response_model=MessageRead)
+async def update_message(message_id: uuid.UUID, data: MessageUpdate, service: MessageService = Depends(get_service)) -> MessageRead:
+    updated = await service.update_message(message_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return MessageRead.model_validate(updated)
+
+
+@router.delete("/{message_id}")
+async def delete_message(message_id: uuid.UUID, service: MessageService = Depends(get_service)) -> None:
+    deleted = await service.delete_message(message_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return None

--- a/src/app/db/models/__init__.py
+++ b/src/app/db/models/__init__.py
@@ -1,0 +1,3 @@
+from .message import Message
+
+__all__ = ["Message"]

--- a/src/app/db/models/message.py
+++ b/src/app/db/models/message.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import uuid
+import datetime
+from sqlalchemy import String, Text, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
+
+from app.db.base import Base
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    author: Mapped[str] = mapped_column(String(length=100), nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/src/app/domain/message/__init__.py
+++ b/src/app/domain/message/__init__.py
@@ -1,0 +1,3 @@
+from .models import Message
+
+__all__ = ["Message"]

--- a/src/app/domain/message/models.py
+++ b/src/app/domain/message/models.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from datetime import datetime
+import uuid
+
+@dataclass
+class Message:
+    id: uuid.UUID
+    content: str
+    author: str
+    created_at: datetime
+    updated_at: datetime

--- a/src/app/infrastructure/messages/dao.py
+++ b/src/app/infrastructure/messages/dao.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import uuid
+from typing import Sequence
+
+from app.infrastructure.messages.repository import MessageRepository
+from app.schemas.message import MessageCreate, MessageUpdate
+from app.db.models import Message
+
+class MessageDAO:
+    def __init__(self: MessageDAO, repository: MessageRepository) -> None:
+        self.repository = repository
+
+    async def create_message(self: MessageDAO, data: MessageCreate) -> Message:
+        return await self.repository.create(content=data.content, author=data.author)
+
+    async def get_message(self: MessageDAO, message_id: uuid.UUID) -> Message | None:
+        return await self.repository.get(message_id)
+
+    async def get_all_messages(self: MessageDAO) -> Sequence[Message]:
+        return await self.repository.get_all()
+
+    async def update_message(self: MessageDAO, message_id: uuid.UUID, data: MessageUpdate) -> Message | None:
+        return await self.repository.update(message_id, content=data.content, author=data.author)
+
+    async def delete_message(self: MessageDAO, message_id: uuid.UUID) -> bool:
+        return await self.repository.delete(message_id)

--- a/src/app/infrastructure/messages/repository.py
+++ b/src/app/infrastructure/messages/repository.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from typing import Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.db.models import Message
+
+class MessageRepository:
+    def __init__(self: MessageRepository, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create(self: MessageRepository, *, content: str, author: str) -> Message:
+        message = Message(content=content, author=author)
+        self.session.add(message)
+        await self.session.commit()
+        await self.session.refresh(message)
+        return message
+
+    async def get(self: MessageRepository, message_id: uuid.UUID) -> Message | None:
+        return await self.session.get(Message, message_id)
+
+    async def get_all(self: MessageRepository) -> Sequence[Message]:
+        result = await self.session.execute(select(Message))
+        return result.scalars().all()
+
+    async def update(self: MessageRepository, message_id: uuid.UUID, *, content: str | None = None, author: str | None = None) -> Message | None:
+        message = await self.get(message_id)
+        if not message:
+            return None
+        if content is not None:
+            message.content = content
+        if author is not None:
+            message.author = author
+        await self.session.commit()
+        await self.session.refresh(message)
+        return message
+
+    async def delete(self: MessageRepository, message_id: uuid.UUID) -> bool:
+        message = await self.get(message_id)
+        if not message:
+            return False
+        await self.session.delete(message)
+        await self.session.commit()
+        return True

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.api.api import router as api_router
+from app.core.settings import get_settings
+
+settings = get_settings()
+
+app = FastAPI(title=settings.project_name, version=settings.version, description=settings.description)
+app.include_router(api_router)

--- a/src/app/schemas/message.py
+++ b/src/app/schemas/message.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pydantic import BaseModel
+
+class MessageCreate(BaseModel):
+    content: str
+    author: str
+
+class MessageUpdate(BaseModel):
+    content: str | None = None
+    author: str | None = None
+
+class MessageRead(BaseModel):
+    id: uuid.UUID
+    content: str
+    author: str
+    created_at: datetime
+    updated_at: datetime

--- a/src/app/services/message_service.py
+++ b/src/app/services/message_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import uuid
+from typing import Sequence
+
+from app.infrastructure.messages.dao import MessageDAO
+from app.schemas.message import MessageCreate, MessageUpdate
+from app.db.models import Message
+
+class MessageService:
+    def __init__(self: MessageService, dao: MessageDAO) -> None:
+        self.dao = dao
+
+    async def create_message(self: MessageService, data: MessageCreate) -> Message:
+        return await self.dao.create_message(data)
+
+    async def get_message(self: MessageService, message_id: uuid.UUID) -> Message | None:
+        return await self.dao.get_message(message_id)
+
+    async def get_all_messages(self: MessageService) -> Sequence[Message]:
+        return await self.dao.get_all_messages()
+
+    async def update_message(self: MessageService, message_id: uuid.UUID, data: MessageUpdate) -> Message | None:
+        return await self.dao.update_message(message_id, data)
+
+    async def delete_message(self: MessageService, message_id: uuid.UUID) -> bool:
+        return await self.dao.delete_message(message_id)

--- a/tests/api/test_messages_api.py
+++ b/tests/api/test_messages_api.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.routes.messages import router as messages_router
+from app.db.session import get_async_session
+
+@pytest.fixture
+async def test_app(db_session: AsyncSession) -> FastAPI:
+    app = FastAPI()
+
+    async def override() -> AsyncSession:
+        yield db_session
+
+    app.dependency_overrides[get_async_session] = override
+    app.include_router(messages_router)
+    return app
+
+
+@pytest.mark.anyio
+async def test_messages_api_crud(test_app: FastAPI) -> None:
+    async with AsyncClient(app=test_app, base_url="http://test") as ac:
+        resp = await ac.post("/api/messages/", json={"content": "hello", "author": "tester"})
+        assert resp.status_code == 201
+        data = resp.json()
+        message_id = data["id"]
+
+        resp = await ac.get(f"/api/messages/{message_id}")
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "hello"
+
+        resp = await ac.put(f"/api/messages/{message_id}", json={"content": "hi"})
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "hi"
+
+        resp = await ac.get("/api/messages/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        resp = await ac.delete(f"/api/messages/{message_id}")
+        assert resp.status_code == 200
+
+        resp = await ac.get(f"/api/messages/{message_id}")
+        assert resp.status_code == 404

--- a/tests/db/test_message_dao.py
+++ b/tests/db/test_message_dao.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.messages.repository import MessageRepository
+from app.infrastructure.messages.dao import MessageDAO
+from app.schemas.message import MessageCreate, MessageUpdate
+
+@pytest.mark.anyio
+@pytest.mark.unit
+async def test_message_dao_crud(db_session: AsyncSession) -> None:
+    repo = MessageRepository(db_session)
+    dao = MessageDAO(repo)
+
+    created = await dao.create_message(MessageCreate(content="hello", author="tester"))
+    assert created.id
+
+    fetched = await dao.get_message(created.id)
+    assert fetched is not None and fetched.content == "hello"
+
+    all_msgs = await dao.get_all_messages()
+    assert len(all_msgs) == 1
+
+    updated = await dao.update_message(created.id, MessageUpdate(content="hi"))
+    assert updated and updated.content == "hi"
+
+    deleted = await dao.delete_message(created.id)
+    assert deleted is True
+    assert await dao.get_message(created.id) is None

--- a/tests/db/test_message_repository.py
+++ b/tests/db/test_message_repository.py
@@ -1,0 +1,26 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.messages.repository import MessageRepository
+
+@pytest.mark.anyio
+@pytest.mark.unit
+async def test_message_repository_crud(db_session: AsyncSession) -> None:
+    repo = MessageRepository(db_session)
+
+    created = await repo.create(content="hello", author="tester")
+    assert created.id is not None
+
+    fetched = await repo.get(created.id)
+    assert fetched is not None
+    assert fetched.content == "hello"
+
+    all_msgs = await repo.get_all()
+    assert len(all_msgs) == 1
+
+    updated = await repo.update(created.id, content="hi")
+    assert updated and updated.content == "hi"
+
+    deleted = await repo.delete(created.id)
+    assert deleted is True
+    assert await repo.get(created.id) is None


### PR DESCRIPTION
## Summary
- create alembic setup and initial migration for messages table
- implement Message ORM model
- add CRUD repository, DAO, and service
- expose `/api/messages` router with full CRUD endpoints
- wire router into API and create FastAPI `app`
- provide pydantic schemas and domain model
- add unit tests for repository, DAO, and API

## Testing
- `poetry run pytest -q` *(fails: Missing required plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6855ede0bc8c832c9b9ddf3600cee27c